### PR TITLE
Customisable "stroke-linecap"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Name | Default value | Description
 `stopColor` | `#429321` | The secondary color of the progress bar gradient.
 `innerStrokeColor` | `#323232` | Background color of the progress bar.
 `strokeWidth` | `10` | The width of the progress bar.
+`strokeLinecap` | `round` | The type of stroke linecap for circle.
 `animateSpeed` | `1000` | The amount of time in milliseconds to animate one step.
 `fps` | `60` | The frames per second that the animation should run.
 `timingFunc` | `linear` | The transition timing function to use for the CSS transition. See [transition-timing-function](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function).

--- a/src/RadialProgressBar.vue
+++ b/src/RadialProgressBar.vue
@@ -78,7 +78,7 @@ export default {
     strokeLinecap: {
       type: String,
       required: false,
-      default 'round'
+      default: 'round'
     },
     animateSpeed: {
       type: Number,

--- a/src/RadialProgressBar.vue
+++ b/src/RadialProgressBar.vue
@@ -26,7 +26,7 @@
               :stroke="innerStrokeColor"
               :stroke-dasharray="circumference"
               stroke-dashoffset="0"
-              stroke-linecap="round"
+              :stroke-linecap="strokeLinecap"
               :style="strokeStyle"></circle>
       <circle :transform="'rotate(270, ' + radius + ',' + radius + ')'"
               :r="innerCircleRadius"
@@ -36,7 +36,7 @@
               :stroke="'url(#radial-gradient' + _uid + ')'"
               :stroke-dasharray="circumference"
               :stroke-dashoffset="circumference"
-              stroke-linecap="round"
+              :stroke-linecap="strokeLinecap"
               :style="progressStyle"></circle>
     </svg>
   </div>
@@ -74,6 +74,11 @@ export default {
       type: Number,
       required: false,
       default: 10
+    },
+    strokeLinecap: {
+      type: String,
+      required: false,
+      default 'round'
     },
     animateSpeed: {
       type: Number,


### PR DESCRIPTION
New prop: `strokeLinecap` to support custom values for `stroke-linecap` param in `<circle>` tag. Default to 'round', as was before.

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap