### PR TITLE
feat: use custom id instead of default _uid

### DIFF
--- a/src/RadialProgressBar.vue
+++ b/src/RadialProgressBar.vue
@@ -9,7 +9,7 @@
          version="1.1"
          xmlns="http://www.w3.org/2000/svg">
       <defs>
-        <radialGradient :id="'radial-gradient' + _uid"
+        <radialGradient :id="'radial-gradient' + _id"
                         :fx="gradient.fx"
                         :fy="gradient.fy"
                         :cx="gradient.cx"
@@ -33,7 +33,7 @@
               :cx="radius"
               :cy="radius"
               fill="transparent"
-              :stroke="'url(#radial-gradient' + _uid + ')'"
+              :stroke="'url(#radial-gradient' + _id + ')'"
               :stroke-dasharray="circumference"
               :stroke-dashoffset="circumference"
               :stroke-linecap="strokeLinecap"
@@ -109,6 +109,16 @@ export default {
       type: Boolean,
       required: false,
       default: true
+    },
+    useCustomId:{
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    customId:{
+      type: Number,
+      required: false,
+      default: Math.floor(Math.random() * 100)
     }
   },
 
@@ -206,6 +216,11 @@ export default {
         width: `${this.innerCircleDiameter}px`
       }
     },
+
+    _id () {
+      if (this.useCustomId) return this.customId;
+      return this._uid;
+    }
   },
 
   methods: {


### PR DESCRIPTION
- While rendering it with nuxt, the _uid keep resetting. The two _uid's inside one instance of a radial progress bar read different values.
- We can remedy by passing as props our own custom _id; Especially if I intended to render an array of radial graphs whose data I just fetched from the database. 
- The useCustomId boolean value is for switching between a custom id and the default _uid.

Example usage:
`
<Rounded
            class="mx-auto w-full"
            :diameter="Chart.diameter"
            :total-steps="Chart.totalSteps"
            :completed-steps="parseFloat(checkdata.CHECKLIST_PERCENTAGE)"
            :animate-speed="Chart.animateSpeed"
            :stroke-width="Chart.strokeWidth"
            :inner-stroke-width="Chart.innerStrokeWidth"
            :stroke-linecap="Chart.strokeLinecap"
            :start-color="Chart.startColor"
            :stop-color="Chart.stopColor"
            :inner-stroke-color="Chart.innerStrokeColor"
            :timing-func="Chart.timingFunc"
            :is-clockwise="Chart.isClockwise"
            :isCustomId=true
            :customId="randomIdVal"
        >
            <p>{{ parseFloat(value) + "%" }}</p>
        </Rounded>
`

Check out last two props passed to the component ⬆️ 